### PR TITLE
Pretty output JSON files

### DIFF
--- a/src/Fhir.Anonymizer.AzureDataFactoryPipeline/src/DataFactoryCustomActivity.cs
+++ b/src/Fhir.Anonymizer.AzureDataFactoryPipeline/src/DataFactoryCustomActivity.cs
@@ -103,7 +103,7 @@ namespace Fhir.Anonymizer.DataFactoryTool
                 using (var reader = new StreamReader(inputDownloadInfo.Value.Content))
                 {
                     string input = await reader.ReadToEndAsync();
-                    string output = _engine.AnonymizeJson(input);
+                    string output = _engine.AnonymizeJson(input, isPrettyOutput: true);
 
                     using (MemoryStream outputStream = new MemoryStream(reader.CurrentEncoding.GetBytes(output)))
                     {

--- a/src/Fhir.Anonymizer.Core.UnitTests/AnonymizerEngineTests.cs
+++ b/src/Fhir.Anonymizer.Core.UnitTests/AnonymizerEngineTests.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Fhir.Anonymizer.Core.AnonymizerConfigurations;
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Serialization;
+using Xunit;
+
+namespace Fhir.Anonymizer.Core.UnitTests
+{
+    public class AnonymizerEngineTests
+    {
+        private readonly AnonymizerEngine _engine = new AnonymizerEngine(Path.Combine("TestConfigurations", "configuration-test-sample.json"));
+
+        [Fact]
+        public void GivenIsPrettyOutputSetTrue_WhenAnonymizeJson_PrettyJsonOutputShouldBeReturned()
+        {
+            var result = _engine.AnonymizeJson(TestPatientSample, isPrettyOutput: true);
+            Assert.Equal(PrettyOutputTarget, result);
+        }
+
+        [Fact]
+        public void GivenIsPrettyOutputSetFalse_WhenAnonymizeJson_OneLineJsonOutputShouldBeReturned()
+        {
+            var result = _engine.AnonymizeJson(TestPatientSample);
+            Assert.Equal(OneLineOutputTarget, result);
+        }
+
+        private const string TestPatientSample =
+@"{
+  ""resourceType"": ""Patient"",
+  ""id"": ""example"",
+  ""name"": [
+    {
+      ""use"": ""official"",
+      ""family"": ""Chalmers"",
+      ""given"": [
+        ""Peter"",
+        ""James""
+      ]
+    }
+  ]
+}";
+
+        private const string PrettyOutputTarget =
+@"{
+  ""resourceType"": ""Patient"",
+  ""id"": ""example"",
+  ""name"": [
+    {
+      ""use"": """",
+      ""family"": """",
+      ""given"": [
+        """",
+        """"
+      ]
+    }
+  ]
+}";
+
+        private const string OneLineOutputTarget = "{\"resourceType\":\"Patient\",\"id\":\"example\",\"name\":[{\"use\":\"\",\"family\":\"\",\"given\":[\"\",\"\"]}]}";
+    }
+}

--- a/src/Fhir.Anonymizer.Core/AnonymizerEngine.cs
+++ b/src/Fhir.Anonymizer.Core/AnonymizerEngine.cs
@@ -33,7 +33,7 @@ namespace Fhir.Anonymizer.Core
             _logger.LogDebug("AnonymizerEngine initialized successfully");
         }
 
-        public string AnonymizeJson(string json)
+        public string AnonymizeJson(string json, bool isPrettyOutput = false)
         {
             EnsureArg.IsNotNullOrEmpty(json, nameof(json));
 
@@ -47,7 +47,11 @@ namespace Fhir.Anonymizer.Core
                 throw new Exception("Failed to parse json resource, please check the json content.", innerException);
             }
 
-            return AnonymizeResourceNode(root).ToJson();
+            FhirJsonSerializationSettings settings = new FhirJsonSerializationSettings
+            {
+                Pretty = isPrettyOutput
+            };
+            return AnonymizeResourceNode(root).ToJson(settings);
         }
 
         public ElementNode AnonymizeResourceNode(ElementNode root)

--- a/src/Fhir.Anonymizer.Tool/FhirResourceDataProcessor.cs
+++ b/src/Fhir.Anonymizer.Tool/FhirResourceDataProcessor.cs
@@ -42,7 +42,7 @@ namespace Fhir.Anonymizer.Tool
                     var resourceJson = reader.ReadToEnd();
                     try
                     {
-                        var resourceResult = _engine.AnonymizeJson(resourceJson);
+                        var resourceResult = _engine.AnonymizeJson(resourceJson, isPrettyOutput: true);
                         writer.Write(resourceResult);
                         processedCount += 1;
                     }


### PR DESCRIPTION
Solve working item #72762.
- For single resource data (.json), we’ll change the output from one line to formatted JSON.
- For bulk resource data (.ndjson), the output will keep unchanged as formatting is inapplicable for new-line delimited JSON data.
