### PR TITLE
Postal code should become empty string for complete redaction

### DIFF
--- a/src/Fhir.Anonymizer.Core.UnitTests/Processors/RedactProcessorTests.cs
+++ b/src/Fhir.Anonymizer.Core.UnitTests/Processors/RedactProcessorTests.cs
@@ -94,7 +94,7 @@ namespace Fhir.Anonymizer.Core.UnitTests.Processors
             node = ElementNode.FromElement(new FhirString("54321").ToTypedElement());
             node.Name = "postalCode";
             processor.Process(node);
-            Assert.Equal("00000", node.Value.ToString());
+            Assert.Equal(string.Empty, node.Value.ToString());
         }
 
         [Fact]

--- a/src/Fhir.Anonymizer.Core.UnitTests/Utility/PostalCodeUtilityTests.cs
+++ b/src/Fhir.Anonymizer.Core.UnitTests/Utility/PostalCodeUtilityTests.cs
@@ -10,9 +10,9 @@ namespace Fhir.Anonymizer.Core.UnitTests
     {
         public static IEnumerable<object[]> GetPostalCodeDataForRedact()
         {
-            yield return new object[] { "98052", "00000" };
-            yield return new object[] { "10104", "00000" };
-            yield return new object[] { "00000", "00000" };
+            yield return new object[] { "98052" };
+            yield return new object[] { "10104" };
+            yield return new object[] { "00000" };
         }
 
         public static IEnumerable<object[]> GetPostalCodeDataForPartialRedact()
@@ -25,13 +25,13 @@ namespace Fhir.Anonymizer.Core.UnitTests
 
         [Theory]
         [MemberData(nameof(GetPostalCodeDataForRedact))]
-        public void GivenAPostalCode_WhenRedact_ThenDigitsShouldBeRedacted(string postalCode, string expectedPostalCode)
+        public void GivenAPostalCode_WhenRedact_ThenDigitsShouldBeRedacted(string postalCode)
         {
             var node = ElementNode.FromElement(new FhirString(postalCode).ToTypedElement());
             node.Name = "postalCode";
             PostalCodeUtility.RedactPostalCode(node, false, null);
 
-            Assert.Equal(expectedPostalCode.ToString(), node.Value);
+            Assert.Equal(string.Empty, node.Value);
         }
 
         [Theory]

--- a/src/Fhir.Anonymizer.Core/Utility/PostalCodeUtility.cs
+++ b/src/Fhir.Anonymizer.Core/Utility/PostalCodeUtility.cs
@@ -30,7 +30,7 @@ namespace Fhir.Anonymizer.Core.Utility
             }
             else
             {
-                node.Value = new string(s_replacementDigit, node.Value.ToString().Length);
+                node.Value = string.Empty;
             }
         }
     }


### PR DESCRIPTION
Solve working item 72538.
- If enablePartialZipCodesForRedact is false, change the output from 00000 to empty string.
- If enablePartialZipCodesForRedact is true, keep original logic unchanged.