### PR TITLE
Remove empty fields. Remove postal codes for complete redaction.

### DIFF
--- a/src/Fhir.Anonymizer.Core.UnitTests/AnonymizerEngineTests.cs
+++ b/src/Fhir.Anonymizer.Core.UnitTests/AnonymizerEngineTests.cs
@@ -45,19 +45,9 @@ namespace Fhir.Anonymizer.Core.UnitTests
         private const string PrettyOutputTarget =
 @"{
   ""resourceType"": ""Patient"",
-  ""id"": ""example"",
-  ""name"": [
-    {
-      ""use"": """",
-      ""family"": """",
-      ""given"": [
-        """",
-        """"
-      ]
-    }
-  ]
+  ""id"": ""example""
 }";
 
-        private const string OneLineOutputTarget = "{\"resourceType\":\"Patient\",\"id\":\"example\",\"name\":[{\"use\":\"\",\"family\":\"\",\"given\":[\"\",\"\"]}]}";
+        private const string OneLineOutputTarget = "{\"resourceType\":\"Patient\",\"id\":\"example\"}";
     }
 }

--- a/src/Fhir.Anonymizer.Core.UnitTests/Processors/DateShiftProcessorTests.cs
+++ b/src/Fhir.Anonymizer.Core.UnitTests/Processors/DateShiftProcessorTests.cs
@@ -25,7 +25,7 @@ namespace Fhir.Anonymizer.Core.UnitTests.Processors
             processor = new DateShiftProcessor(dateShiftKey: "dummy", enablePartialDatesForRedact: false);
             node = ElementNode.FromElement(testDate.ToTypedElement());
             processor.Process(node);
-            Assert.Equal("", node.Value.ToString());
+            Assert.Null(node.Value);
         }
 
         [Fact]

--- a/src/Fhir.Anonymizer.Core.UnitTests/Processors/RedactProcessorTests.cs
+++ b/src/Fhir.Anonymizer.Core.UnitTests/Processors/RedactProcessorTests.cs
@@ -22,7 +22,7 @@ namespace Fhir.Anonymizer.Core.UnitTests.Processors
             processor = new RedactProcessor(enablePartialDatesForRedact: false, true, true, new List<string>());
             node = ElementNode.FromElement(testDate.ToTypedElement());
             processor.Process(node);
-            Assert.Equal("", node.Value.ToString());
+            Assert.Null(node.Value);
         }
 
         [Fact]
@@ -37,7 +37,7 @@ namespace Fhir.Anonymizer.Core.UnitTests.Processors
             processor = new RedactProcessor(enablePartialDatesForRedact: false, true, true, new List<string>());
             node = ElementNode.FromElement(testDateTime.ToTypedElement());
             processor.Process(node);
-            Assert.Equal("", node.Value.ToString());
+            Assert.Null(node.Value);
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace Fhir.Anonymizer.Core.UnitTests.Processors
             processor = new RedactProcessor(enablePartialDatesForRedact: false, true, true, new List<string>());
             node = ElementNode.FromElement(testInstant.ToTypedElement());
             processor.Process(node);
-            Assert.Equal("", node.Value.ToString());
+            Assert.Null(node.Value);
         }
 
         [Fact]
@@ -62,12 +62,12 @@ namespace Fhir.Anonymizer.Core.UnitTests.Processors
             var age = new Age() { Value = 91 };
             var node = ElementNode.FromElement(age.ToTypedElement()).Children("value").Cast<ElementNode>().FirstOrDefault();
             processor.Process(node);
-            Assert.Equal("", node.Value.ToString());
+            Assert.Null(node.Value);
 
             processor = new RedactProcessor(true, enablePartialAgesForRedact: false, true, new List<string>());
             node = ElementNode.FromElement(age.ToTypedElement()).Children("value").Cast<ElementNode>().FirstOrDefault();
             processor.Process(node);
-            Assert.Equal("", node.Value.ToString());
+            Assert.Null(node.Value);
 
             processor = new RedactProcessor(true, enablePartialAgesForRedact: true, true, new List<string>());
             age = new Age() { Value = 89 };
@@ -94,7 +94,7 @@ namespace Fhir.Anonymizer.Core.UnitTests.Processors
             node = ElementNode.FromElement(new FhirString("54321").ToTypedElement());
             node.Name = "postalCode";
             processor.Process(node);
-            Assert.Equal("00000", node.Value.ToString());
+            Assert.Null(node.Value);
         }
 
         [Fact]
@@ -104,7 +104,7 @@ namespace Fhir.Anonymizer.Core.UnitTests.Processors
             var node = ElementNode.FromElement(new FhirString("TestString").ToTypedElement());
             node.Name = "dummy";
             processor.Process(node);
-            Assert.Equal("", node.Value.ToString());
+            Assert.Null(node.Value);
         }
     }
 }

--- a/src/Fhir.Anonymizer.Core.UnitTests/Utility/DateTimeUtilityTests.cs
+++ b/src/Fhir.Anonymizer.Core.UnitTests/Utility/DateTimeUtilityTests.cs
@@ -15,7 +15,7 @@ namespace Fhir.Anonymizer.Core.UnitTests
             yield return new object[] { new Date("2015"), new Date("2015") };
             yield return new object[] { new Date("2015-02"), new Date("2015") };
             yield return new object[] { new Date("2015-02-07"), new Date("2015") };
-            yield return new object[] { new Date("1925-02-07"), new Date("") };
+            yield return new object[] { new Date("1925-02-07"), null };
         }
 
         public static IEnumerable<object[]> GetDateDataForRedact()
@@ -37,7 +37,7 @@ namespace Fhir.Anonymizer.Core.UnitTests
         public static IEnumerable<object[]> GetDateDataForDateShiftButShouldBeRedacted()
         {
             yield return new object[] { new Date("2015-02"), new Date("2015") };
-            yield return new object[] { new Date("1925-02-07"), new Date("") };
+            yield return new object[] { new Date("1925-02-07"), null };
         }
 
         public static IEnumerable<object[]> GetDateTimeDataForRedact()
@@ -46,7 +46,7 @@ namespace Fhir.Anonymizer.Core.UnitTests
             yield return new object[] { new FhirDateTime("2015-02"), new FhirDateTime("2015") };
             yield return new object[] { new FhirDateTime("2015-02-07"), new FhirDateTime("2015") };
             yield return new object[] { new FhirDateTime("2015-02-07T13:28:17-05:00"), new FhirDateTime("2015") };
-            yield return new object[] { new FhirDateTime("1925-02-07T13:28:17-05:00"), new FhirDateTime("") };
+            yield return new object[] { new FhirDateTime("1925-02-07T13:28:17-05:00"), null };
         }
 
         public static IEnumerable<object[]> GetDateTimeDataForDateShift()
@@ -69,7 +69,7 @@ namespace Fhir.Anonymizer.Core.UnitTests
         public static IEnumerable<object[]> GetDateTimeDataForDateShiftButShouldBeRedacted()
         {
             yield return new object[] { new FhirDateTime("2015-02"), new FhirDateTime("2015") };
-            yield return new object[] { new FhirDateTime("1925-02-07T13:28:17-05:00"), new FhirDateTime("") };
+            yield return new object[] { new FhirDateTime("1925-02-07T13:28:17-05:00"), null };
         }
 
         public static IEnumerable<object[]> GetAgeDataForPartialRedact()
@@ -91,7 +91,7 @@ namespace Fhir.Anonymizer.Core.UnitTests
             var node = ElementNode.FromElement(date.ToTypedElement());
             DateTimeUtility.RedactDateNode(node, true);
 
-            Assert.Equal(expectedDate.ToString(), node.Value);
+            Assert.Equal(expectedDate?.ToString() ?? null, node.Value);
         }
 
         [Theory]
@@ -101,7 +101,7 @@ namespace Fhir.Anonymizer.Core.UnitTests
             var node = ElementNode.FromElement(date.ToTypedElement());
             DateTimeUtility.RedactDateNode(node, false);
 
-            Assert.Empty(node.Value.ToString());
+            Assert.Null(node.Value);
         }
 
         [Theory]
@@ -122,7 +122,7 @@ namespace Fhir.Anonymizer.Core.UnitTests
             var node = ElementNode.FromElement(date.ToTypedElement());
             DateTimeUtility.ShiftDateNode(node, string.Empty, true);
 
-            Assert.Equal(expectedDate.ToString(), node.Value);
+            Assert.Equal(expectedDate?.ToString() ?? null, node.Value);
         }
 
         [Theory]
@@ -132,7 +132,7 @@ namespace Fhir.Anonymizer.Core.UnitTests
             var node = ElementNode.FromElement(dateTime.ToTypedElement());
             DateTimeUtility.RedactDateTimeAndInstantNode(node, true);
 
-            Assert.Equal(expectedDateTime.ToString(), node.Value);
+            Assert.Equal(expectedDateTime?.ToString() ?? null, node.Value);
         }
 
         [Theory]
@@ -162,7 +162,7 @@ namespace Fhir.Anonymizer.Core.UnitTests
             var node = ElementNode.FromElement(dateTime.ToTypedElement());
             DateTimeUtility.ShiftDateTimeAndInstantNode(node, string.Empty, true);
 
-            Assert.Equal(expectedDateTime.ToString(), node.Value);
+            Assert.Equal(expectedDateTime?.ToString() ?? null, node.Value);
         }
 
         [Theory]
@@ -172,7 +172,7 @@ namespace Fhir.Anonymizer.Core.UnitTests
             var node = ElementNode.FromElement(age.ToTypedElement()).Children("value").Cast<ElementNode>().FirstOrDefault();
             DateTimeUtility.RedactAgeDecimalNode(node, true);
 
-            Assert.Equal(int.Parse(age.Value.ToString()) > 89 ? string.Empty : age.Value.ToString(), node.Value.ToString());
+            Assert.Equal(int.Parse(age.Value.ToString()) > 89 ? null : age.Value.ToString(), node.Value?.ToString() ?? null);
         }
 
         [Theory]
@@ -182,7 +182,7 @@ namespace Fhir.Anonymizer.Core.UnitTests
             var node = ElementNode.FromElement(age.ToTypedElement()).Children("value").Cast<ElementNode>().FirstOrDefault();
             DateTimeUtility.RedactAgeDecimalNode(node, false);
 
-            Assert.Empty(node.Value.ToString());
+            Assert.Null(node.Value);
         }
     }
 }

--- a/src/Fhir.Anonymizer.Core.UnitTests/Utility/PostalCodeUtilityTests.cs
+++ b/src/Fhir.Anonymizer.Core.UnitTests/Utility/PostalCodeUtilityTests.cs
@@ -10,9 +10,9 @@ namespace Fhir.Anonymizer.Core.UnitTests
     {
         public static IEnumerable<object[]> GetPostalCodeDataForRedact()
         {
-            yield return new object[] { "98052", "00000" };
-            yield return new object[] { "10104", "00000" };
-            yield return new object[] { "00000", "00000" };
+            yield return new object[] { "98052" };
+            yield return new object[] { "10104" };
+            yield return new object[] { "00000" };
         }
 
         public static IEnumerable<object[]> GetPostalCodeDataForPartialRedact()
@@ -25,13 +25,13 @@ namespace Fhir.Anonymizer.Core.UnitTests
 
         [Theory]
         [MemberData(nameof(GetPostalCodeDataForRedact))]
-        public void GivenAPostalCode_WhenRedact_ThenDigitsShouldBeRedacted(string postalCode, string expectedPostalCode)
+        public void GivenAPostalCode_WhenRedact_ThenDigitsShouldBeRedacted(string postalCode)
         {
             var node = ElementNode.FromElement(new FhirString(postalCode).ToTypedElement());
             node.Name = "postalCode";
             PostalCodeUtility.RedactPostalCode(node, false, null);
 
-            Assert.Equal(expectedPostalCode.ToString(), node.Value);
+            Assert.Null(node.Value);
         }
 
         [Theory]

--- a/src/Fhir.Anonymizer.Core/Processors/RedactProcessor.cs
+++ b/src/Fhir.Anonymizer.Core/Processors/RedactProcessor.cs
@@ -51,7 +51,7 @@ namespace Fhir.Anonymizer.Core.Processors
             }
             else
             {
-                node.Value = string.Empty;
+                node.Value = null;
             }
         }
     }

--- a/src/Fhir.Anonymizer.Core/Utility/DateTimeUtility.cs
+++ b/src/Fhir.Anonymizer.Core/Utility/DateTimeUtility.cs
@@ -39,12 +39,12 @@ namespace Fhir.Anonymizer.Core.Utility
                 if (matchedGroups[s_yearIndex].Captures.Any())
                 {
                     string yearOfDate = matchedGroups[s_yearIndex].Value;
-                    node.Value = IndicateAgeOverThreshold(matchedGroups) ? string.Empty : yearOfDate;
+                    node.Value = IndicateAgeOverThreshold(matchedGroups) ? null : yearOfDate;
                 }
             }
             else
             {
-                node.Value = string.Empty;
+                node.Value = null;
             }
         }
 
@@ -61,12 +61,12 @@ namespace Fhir.Anonymizer.Core.Utility
                 if (matchedGroups[s_yearIndex].Captures.Any())
                 {
                     string yearOfDateTime = matchedGroups[s_yearIndex].Value;
-                    node.Value = IndicateAgeOverThreshold(matchedGroups) ? string.Empty : yearOfDateTime;
+                    node.Value = IndicateAgeOverThreshold(matchedGroups) ? null : yearOfDateTime;
                 }
             }
             else
             {
-                node.Value = string.Empty;
+                node.Value = null;
             }
         }
 
@@ -81,12 +81,12 @@ namespace Fhir.Anonymizer.Core.Utility
             {
                 if (int.Parse(node.Value.ToString()) > s_ageThreshold)
                 {
-                    node.Value = string.Empty;
+                    node.Value = null;
                 }
             }
             else
             {
-                node.Value = string.Empty;
+                node.Value = null;
             }
         }
 

--- a/src/Fhir.Anonymizer.Core/Utility/PostalCodeUtility.cs
+++ b/src/Fhir.Anonymizer.Core/Utility/PostalCodeUtility.cs
@@ -30,7 +30,7 @@ namespace Fhir.Anonymizer.Core.Utility
             }
             else
             {
-                node.Value = new string(s_replacementDigit, node.Value.ToString().Length);
+                node.Value = null;
             }
         }
     }

--- a/src/Fhir.Anonymizer.FunctionalTests/TestResources/bundle-basic-target.json
+++ b/src/Fhir.Anonymizer.FunctionalTests/TestResources/bundle-basic-target.json
@@ -7,27 +7,13 @@
       "fullUrl": "http://example.org/fhir/Patient/23",
       "resource": {
         "resourceType": "Patient",
-        "id": "23",
-        "text": {
-          "status": "",
-          "div": ""
-        },
-        "identifier": [
-          {
-            "system": "",
-            "value": ""
-          }
-        ]
+        "id": "23"
       }
     },
     {
       "fullUrl": "urn:uuid:04121321-4af5-424c-a0e1-ed3aab1c349d",
       "resource": {
-        "resourceType": "Patient",
-        "text": {
-          "status": "",
-          "div": ""
-        }
+        "resourceType": "Patient"
       }
     },
     {
@@ -35,10 +21,6 @@
       "resource": {
         "resourceType": "Observation",
         "id": "123",
-        "text": {
-          "status": "",
-          "div": ""
-        },
         "status": "final",
         "code": {
           "coding": [
@@ -49,7 +31,9 @@
             }
           ]
         },
-        "subject": { "reference": "Patient/23" }
+        "subject": {
+          "reference": "Patient/23"
+        }
       }
     }
   ]

--- a/src/Fhir.Anonymizer.FunctionalTests/TestResources/contained-basic-target.json
+++ b/src/Fhir.Anonymizer.FunctionalTests/TestResources/contained-basic-target.json
@@ -1,16 +1,9 @@
 {
-
   "resourceType": "Condition",
   "contained": [
     {
       "resourceType": "Practitioner",
-      "id": "p1",
-      "name": [
-        {
-          "family": "",
-          "given": [ "" ]
-        }
-      ]
+      "id": "p1"
     }
   ],
   "asserter": {

--- a/src/Fhir.Anonymizer.FunctionalTests/TestResources/contained-in-bundle-target.json
+++ b/src/Fhir.Anonymizer.FunctionalTests/TestResources/contained-in-bundle-target.json
@@ -10,13 +10,7 @@
         "contained": [
           {
             "resourceType": "Practitioner",
-            "id": "p1",
-            "name": [
-              {
-                "family": "",
-                "given": [ "" ]
-              }
-            ]
+            "id": "p1"
           }
         ],
         "asserter": {

--- a/src/Fhir.Anonymizer.FunctionalTests/TestResources/patient-basic-target.json
+++ b/src/Fhir.Anonymizer.FunctionalTests/TestResources/patient-basic-target.json
@@ -1,165 +1,73 @@
 {
-	"resourceType": "Patient",
-	"id": "example",
-	"text": {
-		"status": "",
-		"div": ""
-	},
-	"identifier": [
-		{
-			"use": "",
-			"type": {
-				"coding": [
-					{
-						"system": "",
-						"code": ""
-					}
-				]
-			},
-			"system": "",
-			"value": "",
-			"period": {
-				"start": "2001-02-11"
-			},
-			"assigner": {
-				"display": ""
-			}
-		}
-	],
-	"active": true,
-	"name": [
-		{
-			"use": "",
-			"family": "",
-			"given": [
-				"",
-				""
-			]
-		},
-		{
-			"use": "",
-			"given": [
-				""
-			]
-		},
-		{
-			"use": "",
-			"family": "",
-			"given": [
-				"",
-				""
-			],
-			"period": {
-				"end": "2002"
-			}
-		}
-	],
-	"telecom": [
-		{
-			"use": ""
-		},
-		{
-			"system": "",
-			"value": "",
-			"use": "",
-			"rank": ""
-		},
-		{
-			"system": "",
-			"value": "",
-			"use": "",
-			"rank": ""
-		},
-		{
-			"system": "",
-			"value": "",
-			"use": "",
-			"period": {
-				"end": "2014"
-			}
-		}
-	],
-	"gender": "male",
-	"birthDate": "2000-02-11",
-	"_birthDate": {
-		"extension": [
-			{
-				"url": "",
-				"valueDateTime": "2000-02-11T00:00:00-01:00"
-			}
-		]
-	},
-	"deceasedBoolean": false,
-	"address": [
-		{
-			"use": "",
-			"type": "",
-			"text": "",
-			"line": [
-				""
-			],
-			"city": "",
-			"district": "",
-			"state": "TestState",
-			"postalCode": "12300",
-			"period": {
-				"start": "2000-02-11"
-			}
-		}
-	],
-	"contact": [
-		{
-			"relationship": [
-				{
-					"coding": [
-						{
-							"system": "http://terminology.hl7.org/CodeSystem/v2-0131",
-							"code": "N"
-						}
-					]
-				}
-			],
-			"name": {
-				"family": "",
-				"_family": {
-					"extension": [
-						{
-							"url": "",
-							"valueString": ""
-						}
-					]
-				},
-				"given": [
-					""
-				]
-			},
-			"telecom": [
-				{
-					"system": "",
-					"value": ""
-				}
-			],
-			"address": {
-				"use": "",
-				"type": "",
-				"line": [
-					""
-				],
-				"city": "",
-				"district": "",
-				"state": "TestState",
-				"postalCode": "54300",
-				"period": {
-					"start": "2001-02-11"
-				}
-			},
-			"gender": "female",
-			"period": {
-				"start": "2005"
-			}
-		}
-	],
-	"managingOrganization": {
-		"reference": "Organization/1"
-	}
+  "resourceType": "Patient",
+  "id": "example",
+  "identifier": [
+    {
+      "period": {
+        "start": "2001-02-11"
+      }
+    }
+  ],
+  "active": true,
+  "name": [
+    {
+      "period": {
+        "end": "2002"
+      }
+    }
+  ],
+  "telecom": [
+    {
+      "period": {
+        "end": "2014"
+      }
+    }
+  ],
+  "gender": "male",
+  "birthDate": "2000-02-11",
+  "_birthDate": {
+    "extension": [
+      {
+        "valueDateTime": "2000-02-11T00:00:00-01:00"
+      }
+    ]
+  },
+  "deceasedBoolean": false,
+  "address": [
+    {
+      "state": "TestState",
+      "postalCode": "12300",
+      "period": {
+        "start": "2000-02-11"
+      }
+    }
+  ],
+  "contact": [
+    {
+      "relationship": [
+        {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v2-0131",
+              "code": "N"
+            }
+          ]
+        }
+      ],
+      "address": {
+        "state": "TestState",
+        "postalCode": "54300",
+        "period": {
+          "start": "2001-02-11"
+        }
+      },
+      "gender": "female",
+      "period": {
+        "start": "2005"
+      }
+    }
+  ],
+  "managingOrganization": {
+    "reference": "Organization/1"
+  }
 }


### PR DESCRIPTION
Solve working item #72759.
- If fields are completely empty after processing, we should remove them in the output.

Solve working item #72538.
- If enablePartialZipCodesForRedact is false, change the output from 00000 to empty field.
- If enablePartialZipCodesForRedact is true, keep original logic unchanged.

These two items are fixed together as #72538 depends on #72759.