### PR TITLE
Fix some children types might be overwritten during transforming to path rules

### DIFF
--- a/src/Fhir.Anonymizer.Core.UnitTests/AnonymizerConfigurations/ResourceAnonymizerContextTests.cs
+++ b/src/Fhir.Anonymizer.Core.UnitTests/AnonymizerConfigurations/ResourceAnonymizerContextTests.cs
@@ -29,6 +29,7 @@ namespace Fhir.Anonymizer.Core.UnitTests.AnonymizerConfigurations
 
             Assert.Contains("Patient.address", context.PathSet);
             Assert.Contains("Patient.name", context.PathSet);
+            Assert.Contains("Patient.name.period.start", context.PathSet);
             Assert.Contains("Patient.address.period.start", context.PathSet);
             Assert.Contains("Patient.identifier.period.start", context.PathSet);
         }
@@ -115,7 +116,14 @@ namespace Fhir.Anonymizer.Core.UnitTests.AnonymizerConfigurations
         ""Peter"",
         ""James""
       ]
-    }
+    },
+     {
+      ""use"": ""nickname"",
+      ""text"": ""Nick"",
+      ""period"": {
+        ""start"":""2017-01-01""
+      }
+    },
   ],
   ""address"": [
     {

--- a/src/Fhir.Anonymizer.Core/AnonymizationConfigurations/ResourceAnonymizerContext.cs
+++ b/src/Fhir.Anonymizer.Core/AnonymizationConfigurations/ResourceAnonymizerContext.cs
@@ -25,13 +25,13 @@ namespace Fhir.Anonymizer.Core.AnonymizerConfigurations
             if (typeRules != null && typeRules.Any())
             {
                 var rulePaths = rules.Select(rule => rule.Path).ToHashSet();
-                TransformTypeRulesToPathRules(root, typeRules, rules, rulePaths);
+                TransformTypeRulesToPathRules(root, typeRules, rules, rulePaths, new HashSet<string>());
             }
 
             return new ResourceAnonymizerContext(rules);
         }
 
-        private static void TransformTypeRulesToPathRules(ElementNode node, Dictionary<string, string> typeRules, List<AnonymizerRule> rules, HashSet<string> rulePaths)
+        private static void TransformTypeRulesToPathRules(ElementNode node, Dictionary<string, string> typeRules, List<AnonymizerRule> rules, HashSet<string> rulePaths, HashSet<string> generatedTypePaths)
         {
             if (node.IsContainedNode() || node.IsEntryNode())
             {
@@ -44,18 +44,17 @@ namespace Fhir.Anonymizer.Core.AnonymizerConfigurations
                 return;
             }
 
-            if (typeRules.ContainsKey(node.InstanceType))
+            if (!generatedTypePaths.Contains(path) && typeRules.ContainsKey(node.InstanceType))
             {
                 var rule = new AnonymizerRule(path, typeRules[node.InstanceType], AnonymizerRuleType.TypeRule, node.InstanceType);
-   
                 rules.Add(rule);
-                rulePaths.Add(rule.Path);
+                generatedTypePaths.Add(rule.Path);
             }
 
             var children = node.Children().Cast<ElementNode>();
             foreach (var child in children)
             {
-                TransformTypeRulesToPathRules(child, typeRules, rules, rulePaths);
+                TransformTypeRulesToPathRules(child, typeRules, rules, rulePaths, generatedTypePaths);
             }
         }
     }

--- a/src/Fhir.Anonymizer.Core/AnonymizerEngine.cs
+++ b/src/Fhir.Anonymizer.Core/AnonymizerEngine.cs
@@ -74,9 +74,7 @@ namespace Fhir.Anonymizer.Core
             var resourceId = root.GetNodeId();
             foreach (var rule in resourceContext.RuleList)
             {
-                var pathCompileExpression = new FhirPathCompiler().Compile($"{rule.Path}");
-                var matchedNodes = pathCompileExpression(root, EvaluationContext.CreateDefault())
-                    .Cast<ElementNode>();
+                var matchedNodes = root.Select(rule.Path).Cast<ElementNode>();
 
                 _logger.LogDebug(rule.Type == AnonymizerRuleType.PathRule ?
                     $"Path {rule.Source} matches {matchedNodes.Count()} nodes in resource ID {resourceId}." :


### PR DESCRIPTION
1. Fix some children types might be overwrited during transforming to path rules as shown in test cases.
2. Change FHIR path matching logic to a standard interface supported by [Hl7.FhirPath](https://github.com/FirelyTeam/fhir-net-common/blob/96b109975b55e065965866295efa1ddb80f39bb0/src/Hl7.FhirPath/FhirPath/TypedElementFPExtensions.cs).