### PR TITLE
Personal/yanhon/update fhir net api 203

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
 	<PropertyGroup>
-		<Version>2.1.0</Version>
+		<Version>2.2.0</Version>
 	</PropertyGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ There are a few parameters that can help you customize the noise amount for diff
 - [optional] **rangeType** Define whether the *span* value is *fixed* or *proportional*. The default value is *fixed*. 
 - [optional] **roundTo** A value from 0 to 28 that specifies the number of decimal places to round to. The default value is *0* for integer types and *2* for decimal types. 
 
-Note that the target field should be of either a numeric type (integer, decimal, unsignedInt, positiveInt) or a quantity type (Quantity, SimpleQuantity, Money, etc.). 
+Note that the target field should be of either a numeric type (integer, decimal, unsignedInt, positiveInt) or a quantity type (Quantity). 
 
 ## Generalize method
 As one of the anonymization methods, generalization means mapping values to the higher level of generalization. It is the process of abstracting distinguishing value into a more general, less distinguishing value. Generalization attempts to preserve data utility while also reducing the identifiability of the data. 

--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ There are a few parameters that can help you customize the noise amount for diff
 - [optional] **rangeType** Define whether the *span* value is *fixed* or *proportional*. The default value is *fixed*. 
 - [optional] **roundTo** A value from 0 to 28 that specifies the number of decimal places to round to. The default value is *0* for integer types and *2* for decimal types. 
 
-Note that the target field should be of either a numeric type (integer, decimal, unsignedInt, positiveInt) or a quantity type (Quantity). 
+Note that the target field should be of either a numeric type (integer, decimal, unsignedInt, positiveInt) or a quantity type (Quantity, SimpleQuantity, Money, etc.). 
 
 ## Generalize method
 As one of the anonymization methods, generalization means mapping values to the higher level of generalization. It is the process of abstracting distinguishing value into a more general, less distinguishing value. Generalization attempts to preserve data utility while also reducing the identifiability of the data. 

--- a/src/Microsoft.Health.Fhir.Anonymizer.R4.Core.UnitTests/Microsoft.Health.Fhir.Anonymizer.R4.Core.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.Anonymizer.R4.Core.UnitTests/Microsoft.Health.Fhir.Anonymizer.R4.Core.UnitTests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hl7.Fhir.R4" Version="1.7.0" />
-    <PackageReference Include="Hl7.FhirPath" Version="1.7.0" />
+    <PackageReference Include="Hl7.Fhir.R4" Version="2.0.3" />
+    <PackageReference Include="Hl7.FhirPath" Version="2.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/src/Microsoft.Health.Fhir.Anonymizer.R4.Core/Microsoft.Health.Fhir.Anonymizer.R4.Core.csproj
+++ b/src/Microsoft.Health.Fhir.Anonymizer.R4.Core/Microsoft.Health.Fhir.Anonymizer.R4.Core.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="9.2.0" />
-    <PackageReference Include="Hl7.Fhir.R4" Version="1.7.0" />
-    <PackageReference Include="Hl7.FhirPath" Version="1.7.0" />
+    <PackageReference Include="Hl7.Fhir.R4" Version="2.0.3" />
+    <PackageReference Include="Hl7.FhirPath" Version="2.0.3" />
     <PackageReference Include="MathNet.Numerics" Version="4.11.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/src/Microsoft.Health.Fhir.Anonymizer.R4.FunctionalTests/Microsoft.Health.Fhir.Anonymizer.R4.FunctionalTests.csproj
+++ b/src/Microsoft.Health.Fhir.Anonymizer.R4.FunctionalTests/Microsoft.Health.Fhir.Anonymizer.R4.FunctionalTests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hl7.Fhir.R4" Version="1.7.0" />
-    <PackageReference Include="Hl7.FhirPath" Version="1.7.0" />
+    <PackageReference Include="Hl7.Fhir.R4" Version="2.0.3" />
+    <PackageReference Include="Hl7.FhirPath" Version="2.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="xunit" Version="2.4.0" />

--- a/src/Microsoft.Health.Fhir.Anonymizer.R4.FunctionalTests/VersionSpecificTests.cs
+++ b/src/Microsoft.Health.Fhir.Anonymizer.R4.FunctionalTests/VersionSpecificTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using Hl7.FhirPath;
+using Hl7.Fhir.ElementModel;
 using Microsoft.Health.Fhir.Anonymizer.Core;
 using Microsoft.Health.Fhir.Anonymizer.Core.Extensions;
 using Xunit;
@@ -29,9 +30,14 @@ namespace Microsoft.Health.Fhir.Anonymizer.FunctionalTests
             yield return new object[] { "R4OnlyResource/ServiceRequest.json", "R4OnlyResource/ServiceRequest-target.json" };
         }
 
-        public static IEnumerable<object[]> GetCommonResourcesWithStu3OnlyField()
+        public static IEnumerable<object[]> GetCommonResourcesWithStu3OnlyValue()
         {
             yield return new object[] { "Stu3OnlyResource/Claim-Stu3.json" };
+
+        }
+
+        public static IEnumerable<object[]> GetCommonResourcesWithStu3OnlyElement()
+        {
             yield return new object[] { "Stu3OnlyResource/Account-Stu3.json" };
             yield return new object[] { "Stu3OnlyResource/Contract-Stu3.json" };
         }
@@ -72,13 +78,23 @@ namespace Microsoft.Health.Fhir.Anonymizer.FunctionalTests
         }
 
         [Theory]
-        [MemberData(nameof(GetCommonResourcesWithStu3OnlyField))]
-        public void GivenCommonResourceWithStu3OnlyField_WhenAnonymizing_ExceptionShouldBeThrown(string testFile)
+        [MemberData(nameof(GetCommonResourcesWithStu3OnlyValue))]
+        public void GivenCommonResourceWithStu3OnlyValue_WhenAnonymizing_ExceptionShouldBeThrown(string testFile)
         {
             AnonymizerEngine engine = new AnonymizerEngine("r4-configuration-sample.json");
             string testContent = File.ReadAllText(ResourceTestsFile(testFile));
             
             Assert.Throws<FormatException>(() => engine.AnonymizeJson(testContent));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCommonResourcesWithStu3OnlyElement))]
+        public void GivenCommonResourceWithStu3OnlyElement_WhenAnonymizing_ExceptionShouldBeThrown(string testFile)
+        {
+            AnonymizerEngine engine = new AnonymizerEngine("r4-configuration-sample.json");
+            string testContent = File.ReadAllText(ResourceTestsFile(testFile));
+
+            Assert.Throws<StructuralTypeException>(() => engine.AnonymizeJson(testContent));
         }
 
         private string ResourceTestsFile(string fileName)

--- a/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core.UnitTests/Extensions/FhirPathSymbolExtensionsTests.cs
+++ b/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core.UnitTests/Extensions/FhirPathSymbolExtensionsTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.UnitTests.Extensions
             FhirBoolean boolean = new FhirBoolean();
             FhirString fhirString = new FhirString();
 
-            var nodes = new Primitive[] { date, instant, boolean, fhirString }.Select(n => ElementNode.FromElement(n.ToTypedElement()));
+            var nodes = new PrimitiveType[] { date, instant, boolean, fhirString }.Select(n => ElementNode.FromElement(n.ToTypedElement()));
             
             var results = FhirPathSymbolExtensions.NodesByType(nodes, "string").Select(n => n.Location);
             Assert.Single(results);

--- a/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core.UnitTests/Processors/GeneralizeProcessorTests.cs
+++ b/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core.UnitTests/Processors/GeneralizeProcessorTests.cs
@@ -24,24 +24,24 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.UnitTests.Processors
 
         public static IEnumerable<object[]> GetIntegerNodesToGeneralizeWithRangeMapping()
         {
-            yield return new object[] { new Integer(5), (long)20 };
-            yield return new object[] { new Integer(20), (long)40 };
-            yield return new object[] { new Integer(43), (long)60 };
-            yield return new object[] { new Integer(78), (long)80 };
+            yield return new object[] { new Integer(5), 20 };
+            yield return new object[] { new Integer(20), 40 };
+            yield return new object[] { new Integer(43), 60 };
+            yield return new object[] { new Integer(78), 80 };
             yield return new object[] { new Integer(110), null, "Redact"};
             yield return new object[] { new Integer(110), 110, "Keep" };
         }
 
         public static IEnumerable<object[]> GetIntegerNodesToGeneralizeWithApproximate()
         {
-            yield return new object[] { new Integer(5), (long)-10 };
-            yield return new object[] { new Integer(20), (long)10 };
-            yield return new object[] { new Integer(43), (long)30 };
-            yield return new object[] { new Integer(78), (long)60 };
+            yield return new object[] { new Integer(5), -10 };
+            yield return new object[] { new Integer(20), 10 };
+            yield return new object[] { new Integer(43), 30 };
+            yield return new object[] { new Integer(78), 60 };
             yield return new object[] { new Integer(110), null, "Redact" };
             yield return new object[] { new Integer(110), 110, "Keep" };
-            yield return new object[] { new PositiveInt(24), (long)10 };
-            yield return new object[] { new UnsignedInt(24), (long)10 };
+            yield return new object[] { new PositiveInt(24), 10 };
+            yield return new object[] { new UnsignedInt(24), 10 };
         }
 
         public static IEnumerable<object[]> GetStringNodesToGeneralizeWithValueSet()
@@ -67,11 +67,14 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.UnitTests.Processors
             yield return new object[] { new Date("1990-01-01"), "1990" };
             yield return new object[] { new Date("2000-01-01"), null, "Redact" };
             yield return new object[] { new Date("1990"), "1990", "Redact" };
-            yield return new object[] { new Date("2000"), null, "Redact" };
-            yield return new object[] { new Date("2010"), "2010-01-01", "Redact" };
-            yield return new object[] { new Date("2010-01-01"), null, "Redact" };
+            yield return new object[] { new Date("2000"), "1990", "Redact" };
+            yield return new object[] { new Date("2000-01-01"), null, "Redact" };
+            yield return new object[] { new Date("2010"), "2010-01-01"};
+            yield return new object[] { new Date("2010-01-01"), "2010-01-01" };
+            yield return new object[] { new Date("2010-01-02"), "2010-01-01" };
             yield return new object[] { new Date("2020"), "2020-01-01" };
-            yield return new object[] { new Date("2020-05-20"), "2020-01-01" };
+            yield return new object[] { new Date("2020-01-01"), null, "Redact" };
+            yield return new object[] { new Date("2020-05-20"), null, "Redact" };
             yield return new object[] { new Date("2021-05-20"), "2021-05-20", "Keep" };
         }
 
@@ -88,10 +91,11 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.UnitTests.Processors
             yield return new object[] { new FhirDateTime("2010-01-01"), null };
             yield return new object[] { new FhirDateTime("2010-01-01T00:00:00Z"), null };
             yield return new object[] { new FhirDateTime("2010-01-01T00:00:00+08:00"), "2010-01-01" };
-            yield return new object[] { new FhirDateTime("2010-01-01T00:00:00+08:00"), "2010-01-01" };
+            yield return new object[] { new FhirDateTime("2010-01-01T00:00:00+09:00"), null };
             yield return new object[] { new FhirDateTime("2009-12-31T16:00:00Z"), "2010-01-01" };
-            yield return new object[] { new FhirDateTime("2020-01-01T00:00:00+08:00"), "2020-01-01" };
-            yield return new object[] { new FhirDateTime("2020-01-01"), "2020-01-01" };
+            yield return new object[] { new FhirDateTime("2020-01-01T00:00:00"), "2020-01-01" };
+            yield return new object[] { new FhirDateTime("2020-01-01T00:00:00+08:00"), null};
+            yield return new object[] { new FhirDateTime("2020-01-01"), null };
         }
 
         public static IEnumerable<object[]> GetTimeNodesToGeneralizeWithRangeMapping()
@@ -127,12 +131,16 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.UnitTests.Processors
 
         public static IEnumerable<object[]> GetInvalidCasesExpressions()
         {
-            yield return new object[] { new Integer(5), "{\"$this>='0' and $this<'20'\":\"20\"}" };
-            yield return new object[] { new Integer(5), "{\"$this>=0 and $this<20\":\"$this / 2\"}" };
-            yield return new object[] { new Integer(5), "{\"$this<5.5\":\"$this\"}" };
+            yield return new object[] { new Integer(5), "{\"$this>='0' and $this<'20'\":\"20\"}" }; 
             yield return new object[] { new FhirDateTime("2015-01-01T00:00:00Z"), "{\"$this > @2015-1-1\":\"@2015-01-01\"}" };
             yield return new object[] { new Date("2015-01-01"), "{\"$this > @2015-1-1\":\"@2015-01-01\"}" };
             yield return new object[] { new FhirString("2015-01-01"), "{\"$this > @2015-01-01\":\"@2015-01-01\"}" };
+        }
+
+        public static IEnumerable<object[]> GetIntegerDecimalComparingCases()
+        {
+            yield return new object[] { new Integer(5), "{\"$this>=0 and $this<20\":\"$this / 2\"}", (decimal)2.5 }; 
+            yield return new object[] { new Integer(5), "{\"$this<5.5\":\"$this\"}", 5 }; 
         }
 
         public static IEnumerable<object[]> GetNodesToGeneralizeWithConflictSettings()
@@ -257,6 +265,25 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.UnitTests.Processors
                 VisitedNodes = new HashSet<ElementNode>()
             };
             var settings = CreateApproximateSettingsForInteger(otherValues);
+
+            var processResult = processor.Process(node, context, settings);
+            Assert.True(processResult.IsGeneralized);
+            Assert.Equal(target, node.Value);
+        }
+
+
+        [Theory]
+        [MemberData(nameof(GetIntegerDecimalComparingCases))]
+        public void GivenIntegerDecimalComparingCases_WhenGeneralized_GeneralizedNodeShouldBeReturned(Base data, string cases, object target)
+        {
+            var node = ElementNode.FromElement(data.ToTypedElement());
+
+            GeneralizeProcessor processor = new GeneralizeProcessor();
+            var context = new ProcessContext
+            {
+                VisitedNodes = new HashSet<ElementNode>()
+            };
+            var settings = new Dictionary<string, object> { { "cases", cases } };
 
             var processResult = processor.Process(node, context, settings);
             Assert.True(processResult.IsGeneralized);

--- a/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core.UnitTests/Processors/GeneralizeProcessorTests.cs
+++ b/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core.UnitTests/Processors/GeneralizeProcessorTests.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.UnitTests.Processors
             yield return new object[] { new Date("2000-01-01"), null, "Redact" };
             yield return new object[] { new Date("1990"), "1990", "Redact" };
             yield return new object[] { new Date("2000"), "1990", "Redact" };
-            yield return new object[] { new Date("2000-01-01"), null, "Redact" };
+            yield return new object[] { new Date("2000-01-01"), null};
             yield return new object[] { new Date("2010"), "2010-01-01"};
             yield return new object[] { new Date("2010-01-01"), "2010-01-01" };
             yield return new object[] { new Date("2010-01-02"), "2010-01-01" };

--- a/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core.UnitTests/Processors/PerturbProcessorTests.cs
+++ b/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core.UnitTests/Processors/PerturbProcessorTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.UnitTests.Processors
             };
             yield return new object[] 
             {
-                new SimpleQuantity { Value = decimal.Parse("25,162.1378") },
+                new Quantity { Value = decimal.Parse("25,162.1378") },
                 2.26,
                 2,
                 25161.01,
@@ -134,7 +134,7 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.UnitTests.Processors
             };
             yield return new object[] 
             {
-                new SimpleQuantity { Value = decimal.Parse("25,162.1378") },
+                new Quantity { Value = decimal.Parse("25,162.1378") },
                 1,
                 2,
                 12581.07,

--- a/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core.UnitTests/Processors/Settings/GeneralizeSettingTests.cs
+++ b/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core.UnitTests/Processors/Settings/GeneralizeSettingTests.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.UnitTests.Processors.Settings
             yield return new object[] { new Dictionary<string, object>() { { "path", "Patient.birthDate" }, { "method", "generalize" }, { "cases", "{\"$this<=10 and $this>=0\": \"10\"}" }, { "otherValues", "Keep" } }, "{\r\n  \"$this<=10 and $this>=0\": \"10\"\r\n}", "Keep" };
             yield return new object[] { new Dictionary<string, object>() { { "path", "Patient.birthDate" }, { "method", "generalize" }, { "cases", "{\"$this<=10 and $this>=0\": \"10\"}" }, { "otherValues", "Redact" } }, "{\r\n  \"$this<=10 and $this>=0\": \"10\"\r\n}", "Redact" };
             yield return new object[] { new Dictionary<string, object>() { { "path", "Patient.birthDate" }, { "method", "generalize" }, { "cases", "{\"\": \"\"}" }, { "otherValues", "Redact" } }, "{\r\n  \"\": \"\"\r\n}", "Redact" };
+            yield return new object[] { new Dictionary<string, object>() { { "path", "Patient.birthDate" }, { "method", "generalize" }, { "cases", "{\"$this = @2015-01-01T00:00\": \"@2015-01-01T00:00:00Z\"}" } }, "{\r\n  \"$this = @2015-01-01T00:00\": \"@2015-01-01T00:00:00Z\"\r\n}", "Redact" };
         }
 
         public static IEnumerable<object[]> GetInvalidGeneralizeFhirRuleConfigs()
@@ -23,7 +24,6 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.UnitTests.Processors.Settings
             yield return new object[] { new Dictionary<string, object>() { { "path", "Patient.birthDate" }, { "method", "generalize" }, { "cases", "{\"$this sub 1\": \"10\"}" } } };
             yield return new object[] { new Dictionary<string, object>() { { "path", "Patient.birthDate" }, { "method", "generalize" }, { "cases", "{\"$this<10\"+ \"10++\"}" } } };
             yield return new object[] { new Dictionary<string, object>() { { "path", "Patient.birthDate" }, { "method", "generalize" }, { "cases", "{\"$this<10\": \"10\"}" }, { "otherValues", "unknown" } } };
-            yield return new object[] { new Dictionary<string, object>() { { "path", "Patient.birthDate" }, { "method", "generalize" }, { "cases", "{\"$this = @2015-01-01T00:00\": \"@2015-01-01T00:00:00Z\"}" }} };
             yield return new object[] { new Dictionary<string, object>() { { "path", "Patient.birthDate" }, { "method", "generalize" }, { "cases", "{\"\": \"\"}" }, { "otherValues", "Redact" } } };
             yield return new object[] { new Dictionary<string, object>() { { "path", "Patient.birthDate" }, { "method", "generalize" }, { "otherValues", "Keep" } } };
             yield return new object[] { new Dictionary<string, object>() { { "path", "Patient.birthDate" },  { "cases", "{\"$this<10\": \"10\"}" }, { "otherValues", "Keep" } } };

--- a/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core.UnitTests/Visitors/AnonymizationVisitorTests.cs
+++ b/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core.UnitTests/Visitors/AnonymizationVisitorTests.cs
@@ -563,8 +563,8 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.UnitTests.Visitors
             observation.ReferenceRange.Add(
                 new Observation.ReferenceRangeComponent
                 {
-                    Low = new SimpleQuantity { Value = 10, Unit = "TestUnit" },
-                    High = new SimpleQuantity { Value = 100},
+                    Low = new Quantity { Value = 10, Unit = "TestUnit" },
+                    High = new Quantity { Value = 100},
                 });
             return observation;
         }

--- a/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core/Processors/GeneralizeProcessor.cs
+++ b/src/Microsoft.Health.Fhir.Anonymizer.Shared.Core/Processors/GeneralizeProcessor.cs
@@ -4,8 +4,6 @@ using EnsureThat;
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Hl7.FhirPath;
-using Hl7.Fhir.Serialization;
-using Hl7.Fhir.Support.Model;
 using Microsoft.Health.Fhir.Anonymizer.Core.Models;
 using Microsoft.Health.Fhir.Anonymizer.Core.Processors.Settings;
 using Microsoft.Health.Fhir.Anonymizer.Core.AnonymizerConfigurations;
@@ -27,7 +25,6 @@ namespace Microsoft.Health.Fhir.Anonymizer.Core.Processors
             }
 
             var generalizeSetting = GeneralizeSetting.CreateFromRuleSettings(settings);
-            node.Value = PrimitiveTypeConverter.ConvertTo(node.Value, Primitives.GetNativeRepresentation(node.InstanceType));
             foreach (var eachCase in generalizeSetting.Cases)
             {
                 try

--- a/src/Microsoft.Health.Fhir.Anonymizer.Stu3.Core.UnitTests/Microsoft.Health.Fhir.Anonymizer.Stu3.Core.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.Anonymizer.Stu3.Core.UnitTests/Microsoft.Health.Fhir.Anonymizer.Stu3.Core.UnitTests.csproj
@@ -11,8 +11,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Hl7.Fhir.STU3" Version="1.7.0" />
-    <PackageReference Include="Hl7.FhirPath" Version="1.7.0" />
+    <PackageReference Include="Hl7.Fhir.STU3" Version="2.0.3" />
+    <PackageReference Include="Hl7.FhirPath" Version="2.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="xunit" Version="2.4.0" />

--- a/src/Microsoft.Health.Fhir.Anonymizer.Stu3.Core/Microsoft.Health.Fhir.Anonymizer.Stu3.Core.csproj
+++ b/src/Microsoft.Health.Fhir.Anonymizer.Stu3.Core/Microsoft.Health.Fhir.Anonymizer.Stu3.Core.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="9.2.0" />
-    <PackageReference Include="Hl7.Fhir.STU3" Version="1.7.0" />
-    <PackageReference Include="Hl7.FhirPath" Version="1.7.0" />
+    <PackageReference Include="Hl7.Fhir.STU3" Version="2.0.3" />
+    <PackageReference Include="Hl7.FhirPath" Version="2.0.3" />
     <PackageReference Include="MathNet.Numerics" Version="4.11.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/src/Microsoft.Health.Fhir.Anonymizer.Stu3.FunctionalTests/Microsoft.Health.Fhir.Anonymizer.Stu3.FunctionalTests.csproj
+++ b/src/Microsoft.Health.Fhir.Anonymizer.Stu3.FunctionalTests/Microsoft.Health.Fhir.Anonymizer.Stu3.FunctionalTests.csproj
@@ -11,8 +11,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Hl7.Fhir.STU3" Version="1.7.0" />
-    <PackageReference Include="Hl7.FhirPath" Version="1.7.0" />
+    <PackageReference Include="Hl7.Fhir.STU3" Version="2.0.3" />
+    <PackageReference Include="Hl7.FhirPath" Version="2.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.0" />

--- a/src/Microsoft.Health.Fhir.Anonymizer.Stu3.FunctionalTests/VersionSpecificTests.cs
+++ b/src/Microsoft.Health.Fhir.Anonymizer.Stu3.FunctionalTests/VersionSpecificTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using Hl7.FhirPath;
+using Hl7.Fhir.ElementModel;
 using Microsoft.Health.Fhir.Anonymizer.Core;
 using Microsoft.Health.Fhir.Anonymizer.Core.Extensions;
 using Xunit;
@@ -36,12 +37,17 @@ namespace Microsoft.Health.Fhir.Anonymizer.FunctionalTests
             yield return new object[] { "Stu3OnlyResource/Contract-Stu3.json", "Stu3OnlyResource/Contract-Stu3-target.json" };
         }
 
-        public static IEnumerable<object[]> GetCommonResourcesWithR4OnlyField()
+        public static IEnumerable<object[]> GetCommonResourcesWithR4OnlyValue()
         {
             yield return new object[] { "R4OnlyResource/Claim-R4.json" };
-            yield return new object[] { "R4OnlyResource/Account-R4.json" };
+        }
+
+        public static IEnumerable<object[]> GetCommonResourcesWithR4OnlyElement()
+        {
             yield return new object[] { "R4OnlyResource/Contract-R4.json" };
-        }   
+            yield return new object[] { "R4OnlyResource/Account-R4.json" };
+
+        }
 
         [Theory]
         [MemberData(nameof(GetR4OnlyResources))]
@@ -72,12 +78,21 @@ namespace Microsoft.Health.Fhir.Anonymizer.FunctionalTests
         }
 
         [Theory]
-        [MemberData(nameof(GetCommonResourcesWithR4OnlyField))]
-        public void GivenCommonResourceWithR4OnlyField_WhenAnonymizing_ExceptionShouldBeThrown(string testFile)
-        { 
+        [MemberData(nameof(GetCommonResourcesWithR4OnlyValue))]
+        public void GivenCommonResourceWithR4OnlyValue_WhenAnonymizing_ExceptionShouldBeThrown(string testFile)
+        {
             AnonymizerEngine engine = new AnonymizerEngine("stu3-configuration-sample.json");
             string testContent = File.ReadAllText(ResourceTestsFile(testFile));
             Assert.Throws<FormatException>(() => engine.AnonymizeJson(testContent));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCommonResourcesWithR4OnlyElement))]
+        public void GivenCommonResourceWithR4OnlyElement_WhenAnonymizing_ExceptionShouldBeThrown(string testFile)
+        {
+            AnonymizerEngine engine = new AnonymizerEngine("stu3-configuration-sample.json");
+            string testContent = File.ReadAllText(ResourceTestsFile(testFile));
+            Assert.Throws<StructuralTypeException>(() => engine.AnonymizeJson(testContent));
         }
 
         private string ResourceTestsFile(string fileName)


### PR DESCRIPTION
update the fhir net sdk to 2.0.3, the breaking changes related to this project are (https://github.com/FirelyTeam/firely-net-sdk/wiki/Breaking-changes-in-2.0):

- SimpleQuantity and MoneyQuantity (R4+) have been removed, and Quantity is used.
- Type Primitive has been renamed to PrimitiveType.
- The FhirPath engine is upgraded to support FhirPath normative. Equality, equivalence and ordering for (partial) datetimes has been tweaked to better deal with difference in precision.
- The "Primitives.GetNativeRepresentation" API has been removed.