### PR TITLE
update fhir net api to 3.0.0

### DIFF
--- a/src/Microsoft.Health.Fhir.Anonymizer.R4.Core.UnitTests/Microsoft.Health.Fhir.Anonymizer.R4.Core.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.Anonymizer.R4.Core.UnitTests/Microsoft.Health.Fhir.Anonymizer.R4.Core.UnitTests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hl7.Fhir.R4" Version="2.0.3" />
-    <PackageReference Include="Hl7.FhirPath" Version="2.0.3" />
+    <PackageReference Include="Hl7.Fhir.R4" Version="3.0.0" />
+    <PackageReference Include="Hl7.FhirPath" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/src/Microsoft.Health.Fhir.Anonymizer.R4.Core/Microsoft.Health.Fhir.Anonymizer.R4.Core.csproj
+++ b/src/Microsoft.Health.Fhir.Anonymizer.R4.Core/Microsoft.Health.Fhir.Anonymizer.R4.Core.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="9.2.0" />
-    <PackageReference Include="Hl7.Fhir.R4" Version="2.0.3" />
-    <PackageReference Include="Hl7.FhirPath" Version="2.0.3" />
+    <PackageReference Include="Hl7.Fhir.R4" Version="3.0.0" />
+    <PackageReference Include="Hl7.FhirPath" Version="3.0.0" />
     <PackageReference Include="MathNet.Numerics" Version="4.11.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/src/Microsoft.Health.Fhir.Anonymizer.R4.FunctionalTests/Microsoft.Health.Fhir.Anonymizer.R4.FunctionalTests.csproj
+++ b/src/Microsoft.Health.Fhir.Anonymizer.R4.FunctionalTests/Microsoft.Health.Fhir.Anonymizer.R4.FunctionalTests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hl7.Fhir.R4" Version="2.0.3" />
-    <PackageReference Include="Hl7.FhirPath" Version="2.0.3" />
+    <PackageReference Include="Hl7.Fhir.R4" Version="3.0.0" />
+    <PackageReference Include="Hl7.FhirPath" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="xunit" Version="2.4.0" />

--- a/src/Microsoft.Health.Fhir.Anonymizer.Stu3.Core.UnitTests/Microsoft.Health.Fhir.Anonymizer.Stu3.Core.UnitTests.csproj
+++ b/src/Microsoft.Health.Fhir.Anonymizer.Stu3.Core.UnitTests/Microsoft.Health.Fhir.Anonymizer.Stu3.Core.UnitTests.csproj
@@ -11,8 +11,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Hl7.Fhir.STU3" Version="2.0.3" />
-    <PackageReference Include="Hl7.FhirPath" Version="2.0.3" />
+    <PackageReference Include="Hl7.Fhir.STU3" Version="3.0.0" />
+    <PackageReference Include="Hl7.FhirPath" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="xunit" Version="2.4.0" />

--- a/src/Microsoft.Health.Fhir.Anonymizer.Stu3.Core/Microsoft.Health.Fhir.Anonymizer.Stu3.Core.csproj
+++ b/src/Microsoft.Health.Fhir.Anonymizer.Stu3.Core/Microsoft.Health.Fhir.Anonymizer.Stu3.Core.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Ensure.That" Version="9.2.0" />
-    <PackageReference Include="Hl7.Fhir.STU3" Version="2.0.3" />
-    <PackageReference Include="Hl7.FhirPath" Version="2.0.3" />
+    <PackageReference Include="Hl7.Fhir.STU3" Version="3.0.0" />
+    <PackageReference Include="Hl7.FhirPath" Version="3.0.0" />
     <PackageReference Include="MathNet.Numerics" Version="4.11.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/src/Microsoft.Health.Fhir.Anonymizer.Stu3.FunctionalTests/Microsoft.Health.Fhir.Anonymizer.Stu3.FunctionalTests.csproj
+++ b/src/Microsoft.Health.Fhir.Anonymizer.Stu3.FunctionalTests/Microsoft.Health.Fhir.Anonymizer.Stu3.FunctionalTests.csproj
@@ -11,8 +11,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Hl7.Fhir.STU3" Version="2.0.3" />
-    <PackageReference Include="Hl7.FhirPath" Version="2.0.3" />
+    <PackageReference Include="Hl7.Fhir.STU3" Version="3.0.0" />
+    <PackageReference Include="Hl7.FhirPath" Version="3.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.0" />


### PR DESCRIPTION
Update the fhir net sdk to 3.0.0.
The breaking changes in 3.0 is https://github.com/FirelyTeam/firely-net-sdk/wiki/Breaking-changes-in-3.0 